### PR TITLE
Switch to msgpack format by default instead of Marshal format

### DIFF
--- a/bloom_fit.gemspec
+++ b/bloom_fit.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("{app,exe,ext,lib,test,spec}/**/*") + Dir.glob("{LICENSE,README}*")
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "msgpack", "~> 1.0"
+
   spec.required_ruby_version = ">= 3.2.0"
 
   spec.extensions = ["ext/cbloomfilter/extconf.rb"]

--- a/lib/bloom_fit.rb
+++ b/lib/bloom_fit.rb
@@ -1,4 +1,5 @@
 require "forwardable"
+require "msgpack"
 
 require "cbloomfilter"
 require "bloom_fit/version"
@@ -233,16 +234,27 @@ class BloomFit
     [size, hashes, bitmap]
   end
 
-  # Loads a filter from a file previously written by +save+.
-  #
-  # The file is read using Ruby's +Marshal+ format, so it should only be used
-  # with trusted input.
-  def self.load(filename)
-    Marshal.load(File.binread(filename)) # rubocop:disable Security/MarshalLoad
+  # Rebuilds a filter from the serialized data returned by +to_msgpack+.
+  def self.unpack(msg)
+    BloomFit.allocate.tap do |bf|
+      bf.marshal_load(MessagePack.unpack(msg))
+    end
   end
 
-  # Writes the filter to +filename+ using Ruby's +Marshal+ format.
+  # Returns the data to serialize this filter in msgpack format.
+  def to_msgpack
+    MessagePack.pack(marshal_dump)
+  end
+
+  # Loads a filter from a file previously written by +save+.
+  #
+  # The file is read using msgpack format.
+  def self.load(filename)
+    unpack(File.binread(filename))
+  end
+
+  # Writes the filter to +filename+ using msgpack format.
   def save(filename)
-    File.binwrite(filename, Marshal.dump(self))
+    File.binwrite(filename, to_msgpack)
   end
 end

--- a/test/bloom_fit_test.rb
+++ b/test/bloom_fit_test.rb
@@ -358,13 +358,22 @@ class BloomFitTest < Minitest::Spec
   describe "serialization" do
     after { FileUtils.rm_f("bf.out") }
 
-    it "marshalls" do
+    it "packs and unpacks" do
+      bf = BloomFit.new(size: 111, hashes: 5)
+      msg = bf.to_msgpack
+      bf2 = BloomFit.unpack(msg)
+      assert_equal 111, bf2.size
+      assert_equal 5, bf2.hashes
+      assert_empty bf2
+    end
+
+    it "saves" do
       bf = BloomFit.new
       assert bf.save("bf.out")
     end
 
     it "uses binary file io" do
-      dumped = Marshal.dump(subject)
+      dumped = subject.to_msgpack
       writer = Minitest::Mock.new
       writer.expect(:call, dumped.bytesize, ["bf.out", dumped])
 
@@ -385,7 +394,7 @@ class BloomFitTest < Minitest::Spec
       reader.verify
     end
 
-    it "loads from marshalled" do
+    it "loads" do
       subject.add("foo")
       subject.add("bar")
       subject.save("bf.out")


### PR DESCRIPTION
msgpack only supports primative types, so it makes it a much safer way to serialize data from and to ruby.

- https://msgpack.org/
- https://github.com/msgpack/msgpack-ruby

---

Marshal.load is dangerous:

> Never use [Marshal.load](https://docs.ruby-lang.org/en/3.4/Marshal.html#method-c-load) to deserialize untrusted or user supplied data. Because [Marshal](https://docs.ruby-lang.org/en/3.4/Marshal.html) can deserialize to almost any Ruby object and has full control over instance variables, it is possible to craft a malicious payload that executes code shortly after deserialization.

https://docs.ruby-lang.org/en/3.4/security_rdoc.html